### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ and run it with
 lunatic target/wasm32-wasi/release/<example>.wasm
 ```
 
-This app spawns `1000` child processes and calculate the sum of numbers from 0 to i in each child process,
+This app spawns `1000` child processes and calculates the sum of numbers from 0 to i in each child process,
 then sends the result back to the parent process and prints it. If you wrote some Rust code before this should feel familiar. [Check out the docs for more examples.](https://docs.rs/lunatic/0.2.0/lunatic/)
 
 ## Architecture


### PR DESCRIPTION
Guess I missed one, also renamed Readme.md to README.md