### PR TITLE
re-export net

### DIFF
--- a/stdlib/rust/src/lib.rs
+++ b/stdlib/rust/src/lib.rs
@@ -49,6 +49,7 @@ pub mod net;
 pub mod process;
 
 pub use channel::Channel;
+pub use net::{TcpListener, TcpStream};
 pub use process::Process;
 
 /// Rust doesn't have a native representation for Externrefs.


### PR DESCRIPTION
Fixes issue #11.

Compiling the code from the networking example from this [blog post](https://dev.to/bkolobara/writing-rust-the-elixir-way-2lm8) with `lunatic = { git = "https://github.com/ArneVogel/lunatic", branch = "net" }` instead of `lunatic = "0.2.0"` results in the expected behavior.