### PR TITLE
Fixed failing patching tests

### DIFF
--- a/tests/normalisation_patching_test/memory.wat
+++ b/tests/normalisation_patching_test/memory.wat
@@ -6,7 +6,7 @@
 ;; EXPECTED-RESULT:
 (module
     (type (;0;) (func))
-    (import "lunatic" "yield" (func (;0;) (type 0)))
+    (import "lunatic" "yield_" (func (;0;) (type 0)))
     (import "lunatic" "memory" (memory (;0;) 17))
     (global (;0;) (mut i32) (i32.const 0))
 )

--- a/tests/normalisation_patching_test/simple_reduction_counter.wat
+++ b/tests/normalisation_patching_test/simple_reduction_counter.wat
@@ -10,7 +10,7 @@
     (global (;0 reduction counter ;) (mut i32) (i32.const 0))
     (type (;0 yield type ;) (func))
     (type (;1;) (func (result i32)))
-    (import "lunatic" "yield" (func (;0;) (type 0)))
+    (import "lunatic" "yield_" (func (;0;) (type 0)))
 
     (func (;1;) (type 1) (result i32)
         block  ;; Reduction counter logic


### PR DESCRIPTION
The yield function in the lunatic module was recently renamed to yield_,
but the patching tests still expected yield in the patched modules.